### PR TITLE
Fix graph with pdf select

### DIFF
--- a/src/api/find_citations.js
+++ b/src/api/find_citations.js
@@ -115,12 +115,12 @@ const getFieldsOfStudy = async(ref_dois) => {
 // const url_title_query = url_query + "?query.title=" + pdf_title;
 
 export const findCitations_withTitle = async (pdfTitle) => {
-  console.log(pdfTitle)
+  //console.log(pdfTitle)
   let urlRequest = 'https://api.crossref.org/works?query.title=' + pdfTitle
   let citationData = {}
   let sortedData = {}
   //const org_doi = "10.1371/journal.pclm.0000093"
-  console.log("HELLO4")
+  console.log("In findCitations")
   try {
     const res = await axios.get(
       urlRequest
@@ -132,9 +132,14 @@ export const findCitations_withTitle = async (pdfTitle) => {
     var new_referenced_dois = referenced_dois;
 
     const org_doi = res.data.message.items[0].DOI;
+    citationData.origDOI = org_doi;
+    console.log("Originial DOI: ",org_doi);
     new_referenced_dois.push(org_doi);
 
+
     citationData.fosAndAbstract = await getFieldsOfStudy(new_referenced_dois);
+    console.log("fosAndAbstract: ", citationData.fosAndAbstract);
+
     console.log(citationData);
    // sortedData = sortData(citationData);
     //var abstracts_from_dois = await getAbstracts(new_referenced_dois);

--- a/src/api/find_citations.js
+++ b/src/api/find_citations.js
@@ -42,31 +42,35 @@ function getDOIofReferences(pdf_data){
 const getRefDataByDOI = async(referenced_dois) => {
   let connected_refs = {};
   var keys = {}
+  const queries = [];
   for(let i = 0; i < referenced_dois.length; i++) {
     const url_doi_query = url_query + "/" + referenced_dois[i];
     let ref_info = [];
-    axios.get(
-      url_doi_query
-    )
-    .then(res => {
-      //gets referenced dois of this specific doi
-      var temp_referenced_dois = getDOIofReferences(res.data.message);
-      //storing specific doi info
-      ref_info.author = res.data.message.author;
-      ref_info.title = res.data.message.title;
-      ref_info.doi = res.data.message.DOI;
-      ref_info.references = temp_referenced_dois;
-      // Takes the references of current doi and compares it with the references on the pdf
-      var connected_refs_for_i = getListOfConnectedRefs(referenced_dois, temp_referenced_dois,i);
-      ref_info.connected_refs = connected_refs_for_i;
-      //Add this doi's info on the connected_refs list
-      connected_refs[referenced_dois[i]] = ref_info;  
-      //console.log(i)
-      //console.log(Object.values(connected_refs))
-      keys = Object.keys(connected_refs)
-    })
-    .catch((err)=>console.log(err)); 
+    queries.push(
+      axios.get(
+        url_doi_query
+      )
+      .then(res => {
+        //gets referenced dois of this specific doi
+        var temp_referenced_dois = getDOIofReferences(res.data.message);
+        //storing specific doi info
+        ref_info.author = res.data.message.author;
+        ref_info.title = res.data.message.title;
+        ref_info.doi = res.data.message.DOI;
+        ref_info.references = temp_referenced_dois;
+        // Takes the references of current doi and compares it with the references on the pdf
+        var connected_refs_for_i = getListOfConnectedRefs(referenced_dois, temp_referenced_dois,i);
+        ref_info.connected_refs = connected_refs_for_i;
+        //Add this doi's info on the connected_refs list
+        connected_refs[referenced_dois[i]] = ref_info;  
+        //console.log(i)
+        //console.log(Object.values(connected_refs))
+        keys = Object.keys(connected_refs)
+      })
+      .catch((err)=>console.log(err))
+    );
   }
+  await Promise.all(queries);
   //console.log(connected_refs)
   //console.log("Here")
   //console.log(Object.values(connected_refs)[0])
@@ -92,22 +96,26 @@ function sortData(citationData){
 const getFieldsOfStudy = async(ref_dois) => {
   //console.log(Object.keys(connected_refs))
   let fosAndAbstract = {};
+  const queries = [];
   for(let i = 0; i < ref_dois.length; i++){
     var url_abstract_query = ss_url_query + ref_dois[i] + "?fields=fieldsOfStudy,abstract";
     let ref_info = {}
-    axios.get(
-      url_abstract_query
-    )
-    .then(res => {
-      ref_info.fos = res.data.fieldsOfStudy;
-      ref_info.abstract = res.data.abstract;
-      //ref_info.title = res.data.title;
-      fosAndAbstract[ref_dois[i]] = ref_info
-    })
-    .catch((err)=>console.log(err));
+    queries.push(
+      axios.get(
+        url_abstract_query
+      )
+      .then(res => {
+        ref_info.fos = res.data.fieldsOfStudy;
+        ref_info.abstract = res.data.abstract;
+        //ref_info.title = res.data.title;
+        fosAndAbstract[ref_dois[i]] = ref_info
+      })
+      .catch((err)=>console.log(err))
+    );
   }
+  await Promise.all(queries);
   //console.log(fosAndAbstract[ref_dois[0]])
-  return fosAndAbstract
+  return fosAndAbstract;
 }
 
 // const pdf_title = "Nanometre-scale+thermometry+in+a+living+cell";

--- a/src/api/find_citations.js
+++ b/src/api/find_citations.js
@@ -133,12 +133,12 @@ export const findCitations_withTitle = async (pdfTitle) => {
 
     const org_doi = res.data.message.items[0].DOI;
     citationData.origDOI = org_doi;
-    console.log("Originial DOI: ",org_doi);
+    //console.log("Originial DOI: ",org_doi);
     new_referenced_dois.push(org_doi);
 
 
     citationData.fosAndAbstract = await getFieldsOfStudy(new_referenced_dois);
-    console.log("fosAndAbstract: ", citationData.fosAndAbstract);
+    //console.log("fosAndAbstract: ", citationData.fosAndAbstract);
 
     console.log(citationData);
    // sortedData = sortData(citationData);

--- a/src/components/citationMapping/VisualizeGraph.js
+++ b/src/components/citationMapping/VisualizeGraph.js
@@ -37,35 +37,13 @@ const VisualizeGraph = ({pdfTitle}) => {
   }
   
 
-  //MJ Idek what useEffect does but it looks like we need the find_citations in useEffect. Idek why it's getting called 3 other times tho.
   useEffect(() => {
-    
-    //setDefaultDoi(doi);
-    const title_with_pulses = makeTitlePlus();
-    
-    //setTitlePlus(title_with_pulses)
-    //console.log(title_with_pulses);
-    findCitations_withTitle(title_with_pulses)
-    .then((res) => {
-      setDefaultDoi(res.origDOI);
-      setCitationInfo(res.connected_references);
-      setAbstractFosInfo(res.fosAndAbstract);
-      console.log('finished usedeffect findCitations');
-      //console.log(citationInfo);
-      //console.log(defaultDoi);
-      //getFosToDoi();
-      //getAbstract()
-    });
-    console.log("use effect ran");
-  }, []);
-
-  useEffect(() => {
-    if(citationInfo === null) {
+    if(Object.keys(nodes).length == 0) {
       setLoading(true);
     } else {
       setLoading(false);
     }
-  }, [citationInfo])
+  }, [nodes])
 
   const getNodes = () => { // creates the node in the graph
     if(citationInfo == null) {
@@ -226,11 +204,6 @@ const VisualizeGraph = ({pdfTitle}) => {
   const events = {
     select: function(event) {
       var { nodes, edges } = event;
-      //console.log(nodes);
-      //toggleEdgeView(event,edges);
-      //console.log(nodes[0]);
-      //console.log(graph.edges);
-      //console.log(citationInfo[nodes[0]].author[0].given);
       var title = citationInfo[nodes[0]].title[0];
       var author = citationInfo[nodes[0]].author[0].given + citationInfo[nodes[0]].author[0].family ;
       var abstract = "";
@@ -257,7 +230,6 @@ const VisualizeGraph = ({pdfTitle}) => {
       setAuthor(author);
       setFos(fos);
       setAbstract(abstract);
-      // alert("TITLE: " + title + "\n\nAUTHOR: " + author +"\n\n" + fos + "\n\n" + abstract);
     }
 
   };
@@ -318,6 +290,7 @@ const VisualizeGraph = ({pdfTitle}) => {
             console.log(title_with_pulses);
             findCitations_withTitle(title_with_pulses)
             .then((res) => {
+              setDefaultDoi(res.origDOI);
               setCitationInfo(res.connected_references)
               //console.log(citationInfo);
               setAbstractFosInfo(res.fosAndAbstract)

--- a/src/components/citationMapping/VisualizeGraph.js
+++ b/src/components/citationMapping/VisualizeGraph.js
@@ -12,7 +12,7 @@ import './citationMappingStyle.css'
 //WORKING WITH THE PDF FOR DEMO
 //const title = 'The value of standing forests for birds and people in a biodiversity hotspot'
 //const titlePlus = 'The+value+of+standing+forests+for+birds+and+people+in+a+biodiversity+hotspot';
-const doi = '10.1371/journal.pclm.0000093';
+//const doi = '10.1371/journal.pclm.0000093';
 
 
 const VisualizeGraph = ({pdfTitle}) => {
@@ -27,11 +27,8 @@ const VisualizeGraph = ({pdfTitle}) => {
   const [fos, setFos] = useState(null);
   const [abstract, setAbstract] = useState(null);
   const [title, setTitle] = useState(null);
-  const [pdfTitlePlus, setTitlePlus] = useState(null);
   const [defaultDoi, setDefaultDoi] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [fosColours, setFosColours] = useState(null);
-  const [fosToDoi, setFosToDoi] = useState(null);
 
   const makeTitlePlus = () => {
     var title_with_pulses = pdfTitle.split(' ').join('+');
@@ -47,15 +44,15 @@ const VisualizeGraph = ({pdfTitle}) => {
     const title_with_pulses = makeTitlePlus();
     
     //setTitlePlus(title_with_pulses)
-    console.log(title_with_pulses);
+    //console.log(title_with_pulses);
     findCitations_withTitle(title_with_pulses)
     .then((res) => {
-      setDefaultDoi(doi);
+      setDefaultDoi(res.origDOI);
       setCitationInfo(res.connected_references);
       setAbstractFosInfo(res.fosAndAbstract);
-      console.log('here');
-      console.log(citationInfo);
-      console.log(defaultDoi);
+      console.log('finished usedeffect findCitations');
+      //console.log(citationInfo);
+      //console.log(defaultDoi);
       //getFosToDoi();
       //getAbstract()
     });
@@ -70,65 +67,9 @@ const VisualizeGraph = ({pdfTitle}) => {
     }
   }, [citationInfo])
 
-  const getFosToDoi = () => {
-
-    let fosToDoi_setup = {};
-
-    for(let i = 0; i < Object.keys(citationInfo).length; i++) {
-      if(abstractFosInfo[Object.keys(citationInfo)[i]] != null && abstractFosInfo[Object.keys(citationInfo)[i]].fos != null) {
-
-        for(let j = 0 ; j< abstractFosInfo[Object.keys(citationInfo)[i]].fos.length ; j++){
-          var currField = abstractFosInfo[Object.keys(citationInfo)[i]].fos[j]
-          if (!Object.keys(fosToDoi_setup).includes(currField)){
-            
-            fosToDoi_setup[currField] = [];
-          }
-          if (!fosToDoi_setup[currField].includes(Object.keys(citationInfo)[i])){
-          //console.log("field: ", currField, " id: ", Object.keys(citationInfo)[i]);
-            fosToDoi_setup[currField].push(Object.keys(citationInfo)[i]);
-          }
-      }
-      }
-    }
-    setFosToDoi(fosToDoi_setup);
-  }
-
-  const getFOS = () => {
-    if(citationInfo == null) {
-      return;
-    }
-    let fosColours_setup = {
-      ComputerScience : "#800000",
-      Medicine : "#9a6324",
-      Chemistry : "#808000",
-      Biology : "#469990",
-      MaterialsScience : "#000076",
-      Physics : "#e6194b",
-      Geology : "#ff7f00",
-      Psychology : "#f58231",
-      Art :"#ffe119",
-      History : "#bfef45",
-      Geography : "#3cb44b",
-      Sociology : "#6b238f",
-      Business : "#42d4f4",
-      PoliticalScience : "#6aff00",
-      Economics : "#4363d8",
-      Philosophy : "#911eb4",
-      Mathematics : "#f032e6",
-      Engineering : "#a9a9a9",
-      EnvironmentalScience : "bfff00",
-      AgriculturalandFoodSciences : "#fabed4",
-      Education : "#ffd8b1",
-      Law : "fffac8",
-      Linguistics : "#aaffc3"
-    };
-
-    setFosColours(fosColours_setup);
-    //console.log(fosColours_setup);
-  }
-
   const getNodes = () => { // creates the node in the graph
     if(citationInfo == null) {
+      console.log("citation info is null so nodes is null");
       return;
     }
     let graphNodes = [];
@@ -137,6 +78,7 @@ const VisualizeGraph = ({pdfTitle}) => {
       title: defaultDoi,
       label: pdfTitle
     };
+    console.log("defaultNode: ", defaultNode);
     graphNodes.push(defaultNode);
     for(let i = 0; i < Object.keys(citationInfo).length; i++) {
       var tmpNode = {};
@@ -150,6 +92,7 @@ const VisualizeGraph = ({pdfTitle}) => {
 
   const getEdges = () => {
     if(citationInfo == null) {
+      console.log("citation info is null so edges is null");
       return;
     }
     
@@ -158,6 +101,13 @@ const VisualizeGraph = ({pdfTitle}) => {
     let fosToDoi_setup = {};
     //Note that it only compares to the FIRST fosOrig. This is assuming it only has ONE fos.
     var fosOrig = "";
+    console.log("DefaultDOI:", defaultDoi );
+    if(abstractFosInfo[defaultDoi] == null){
+      console.log("No abstract info for defaultDOI");
+      return;
+    }
+    console.log(abstractFosInfo[defaultDoi]);
+
     if(abstractFosInfo[defaultDoi].fos != null){
       fosOrig = abstractFosInfo[defaultDoi].fos[0];
     }
@@ -235,37 +185,6 @@ const VisualizeGraph = ({pdfTitle}) => {
     }
     
     console.log(fosToDoi_setup.length);
-    /*
-    for( let l = 0 ; l < Object.keys(fosToDoi_setup).length ; l++){
-      console.log("here")
-      var fos = Object.keys(fosToDoi_setup)[l];
-      console.log(fos);
-      for(let m = 0; m < fosToDoi_setup[fos].length -1 ; m++){
-        
-        var index0 = fosToDoi_setup[fos][m];
-        var index1 = fosToDoi_setup[fos][m+1];
-        
-        var tmpEdge0 = {};
-        tmpEdge0.from = index0;
-        tmpEdge0.to = index1;
-        tmpEdge0.label = fos;
-        //tmpEdge0.color = fosColours[fos.replace(/\s/g, '')];  
-        graphEdges.push(tmpEdge0);
-
-        var tmpEdge1 = {};
-        tmpEdge1.from = index1;
-        tmpEdge1.to = index0;
-        tmpEdge1.label = fos;
-        //tmpEdge1.color = fosColours[fos.replace(/\s/g, '')];  
-        graphEdges.push(tmpEdge1);
-
-        console.log(tmpEdge0,tmpEdge1);
-
-      }
-    }
-    */
-
-    // Loop through all that have more than one fOS
     setEdges(graphEdges);
   }
 
@@ -399,14 +318,18 @@ const VisualizeGraph = ({pdfTitle}) => {
         <Button 
           onClick={() => {
             const title_with_pulses = makeTitlePlus();
+            console.log(title_with_pulses);
             findCitations_withTitle(title_with_pulses)
             .then((res) => {
               setCitationInfo(res.connected_references)
+              console.log(citationInfo);
               setAbstractFosInfo(res.fosAndAbstract)
               //getFosToDoi();
               //getFOS();
               getNodes();
+              console.log(nodes);
               getEdges();
+              console.log(edges);
             });
             setShowModal(true);
           }}

--- a/src/components/citationMapping/VisualizeGraph.js
+++ b/src/components/citationMapping/VisualizeGraph.js
@@ -32,7 +32,7 @@ const VisualizeGraph = ({pdfTitle}) => {
 
   const makeTitlePlus = () => {
     var title_with_pulses = pdfTitle.split(' ').join('+');
-    console.log(title_with_pulses)
+    //console.log(title_with_pulses)
     return title_with_pulses;
   }
   
@@ -78,7 +78,6 @@ const VisualizeGraph = ({pdfTitle}) => {
       title: defaultDoi,
       label: pdfTitle
     };
-    console.log("defaultNode: ", defaultNode);
     graphNodes.push(defaultNode);
     for(let i = 0; i < Object.keys(citationInfo).length; i++) {
       var tmpNode = {};
@@ -101,12 +100,10 @@ const VisualizeGraph = ({pdfTitle}) => {
     let fosToDoi_setup = {};
     //Note that it only compares to the FIRST fosOrig. This is assuming it only has ONE fos.
     var fosOrig = "";
-    console.log("DefaultDOI:", defaultDoi );
     if(abstractFosInfo[defaultDoi] == null){
       console.log("No abstract info for defaultDOI");
       return;
     }
-    console.log(abstractFosInfo[defaultDoi]);
 
     if(abstractFosInfo[defaultDoi].fos != null){
       fosOrig = abstractFosInfo[defaultDoi].fos[0];
@@ -184,7 +181,7 @@ const VisualizeGraph = ({pdfTitle}) => {
       }
     }
     
-    console.log(fosToDoi_setup.length);
+    //console.log(fosToDoi_setup.length);
     setEdges(graphEdges);
   }
 
@@ -229,11 +226,11 @@ const VisualizeGraph = ({pdfTitle}) => {
   const events = {
     select: function(event) {
       var { nodes, edges } = event;
-      console.log(nodes);
+      //console.log(nodes);
       //toggleEdgeView(event,edges);
-      console.log(nodes[0]);
+      //console.log(nodes[0]);
       //console.log(graph.edges);
-      console.log(citationInfo[nodes[0]].author[0].given);
+      //console.log(citationInfo[nodes[0]].author[0].given);
       var title = citationInfo[nodes[0]].title[0];
       var author = citationInfo[nodes[0]].author[0].given + citationInfo[nodes[0]].author[0].family ;
       var abstract = "";
@@ -322,14 +319,14 @@ const VisualizeGraph = ({pdfTitle}) => {
             findCitations_withTitle(title_with_pulses)
             .then((res) => {
               setCitationInfo(res.connected_references)
-              console.log(citationInfo);
+              //console.log(citationInfo);
               setAbstractFosInfo(res.fosAndAbstract)
               //getFosToDoi();
               //getFOS();
               getNodes();
-              console.log(nodes);
+              //console.log(nodes);
               getEdges();
-              console.log(edges);
+              //console.log(edges);
             });
             setShowModal(true);
           }}


### PR DESCRIPTION
- cleaned up code on VisualizeGraph.js and Find_Citations.js
- Properly gets pdf title from cermine and creates visualizeGraph.js
- Tested working with pdf files `nature12373.pdf` and `Test3.pdf`

- NOTE: sometimes, it doesn't load graph after the first button click because global vars aren't set the first time. 

You will know it won't load if in the console it says `citation info is null so nodes is null` or `citation info is null so edges is null`
1) after seeing this output wait for a few seconds, 
2) close citation graph module, wait a few seconds, 
3) open citation graph module, wait a few seconds,
4) graph will pop up with full functionality.

**by "wait a few seconds" count to 10 missisipis"**