### PR TITLE
Add loading indicator during extraction

### DIFF
--- a/src/components/Viewer.js
+++ b/src/components/Viewer.js
@@ -34,6 +34,7 @@ const Viewer = ({pdfData, setPdfTitle, setPdfAuthor}) => {
   const summaryURL = 'https://api.meaningcloud.com/summarization-1.0';
   const [textContent, setTextContent] = useState();
   const [viewport, setViewport] = useState();
+  const [loading, setLoading] = useState(1);
   
   const summary = useMemo(() => {
     return summaryArray.join(' ');
@@ -113,7 +114,6 @@ const Viewer = ({pdfData, setPdfTitle, setPdfAuthor}) => {
   const prevPage = () => currentPage > 1 && setCurrentPage(currentPage - 1);
   const firstPage = () => currentPage !== 1 && setCurrentPage(1);
   const lastPage = () => currentPage < totalPages && setCurrentPage(totalPages);
-  
 
   const toggleSidebar = () => {
     setShowSidebar(true);
@@ -150,6 +150,7 @@ async function getPDFText() {
     setBody(result['BODY_CONTENT']);
     setCermAbstract(result['ABSTRACT']);
     getAbstract(result['TITLE']);
+    setLoading(0);
     //setAbstract(abstract_temp1);
 }
 
@@ -403,7 +404,8 @@ function checkValidSentence(str){
 
   return (
     <>
-      <ViewerNavbar 
+      <ViewerNavbar
+        loading = {loading}
         url = {url}
         showSidebar={ showSidebar }
         summary = { summary }

--- a/src/components/viewerComponents/ViewerNavbar.js
+++ b/src/components/viewerComponents/ViewerNavbar.js
@@ -6,10 +6,11 @@ import PropTypes from 'prop-types';
 
 import { BsArrowRight, BsArrowLeft, BsArrowBarRight, BsArrowBarLeft } from 'react-icons/bs';
 import { AiOutlineZoomIn, AiOutlineZoomOut } from 'react-icons/ai';
-import { Button, Nav, Navbar } from 'react-bootstrap';
+import { Button, Nav, Navbar, Spinner } from 'react-bootstrap';
 
 const ViewerNavbar = (props) => {
   const {
+    loading,
     onSummaryClick,
     currentPage,
     totalPageCount,
@@ -94,14 +95,16 @@ const ViewerNavbar = (props) => {
 
   const renderSummaryButton = () => (
     <div>
-      <Button
-        className='mx-3'
-        variant='outline-secondary'
-        size='sm'
-        onClick={ () => onSummaryClick() }    
-      >
-      Generate Summary
-      </Button>
+      { loading ? <Spinner animation="border" /> : 
+        <Button
+          className='mx-3'
+          variant='outline-secondary'
+          size='sm'
+          onClick={ () => onSummaryClick() }    
+        >
+        Generate Summary
+        </Button>
+      }
     </div>
   )
 
@@ -109,6 +112,7 @@ const ViewerNavbar = (props) => {
     <>
       <Navbar bg='dark' variant='dark' className="justify-content-center mb-3">
         <Nav>
+          
           { renderPageCounts() }
           { renderSummaryButton() }
           { renderZoomButtons() }
@@ -119,6 +123,7 @@ const ViewerNavbar = (props) => {
 }
 
 ViewerNavbar.propTypes = {
+  loading: PropTypes.number,
   currentPage: PropTypes.number,
   totalPageCount: PropTypes.number,
   nextPage: PropTypes.func.isRequired,


### PR DESCRIPTION
Generate summary button is replaced with a spinner during API call to backend.

Button shows again when API call is finished.